### PR TITLE
0.34.0: Bump mongochangestream to pick up refresh token improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.34.0
+
+- Latest `mongochangestream` - Performance improvements related to updating the
+  refresh token more often. See [mongochangestream
+  changelog](https://github.com/smartprocure/mongochangestream/blob/master/CHANGELOG.md#0590)
+
 # 0.33.0
 
 - Move re-try logic out of this package.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ Note: source and destination can be the same.
 MONGO_SOURCE_CONN="mongodb+srv://..."
 MONGO_DESTINATION_CONN="mongodb+srv://..."
 ```
+
+Then run `npm test` to run the tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "mongo2mongo",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo2mongo",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.0",
         "eventemitter3": "^5.0.1",
         "lodash": "^4.17.21",
-        "mongochangestream": "^0.58.0",
+        "mongochangestream": "^0.59.0",
         "obj-walker": "^2.4.0",
         "p-retry": "^6.2.1",
         "prom-utils": "^0.14.0"
@@ -2687,9 +2687,10 @@
       }
     },
     "node_modules/mongochangestream": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.58.0.tgz",
-      "integrity": "sha512-UUs3JsyKORSJjqwg6ADV8GBYSptIHPO1I+E0RhFjjKk3B/14lgLb5OcKZrYo3DYg+ObysVZw2bkPPGzkdsuNcw==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.59.0.tgz",
+      "integrity": "sha512-MJBvX5YUXvv3/Hrl+fYlQ3AXFJaKJnUIyP3w3vkPyNAbvFSEZdmalaGKDlR2KHmM0osh5vTKUu/sq+QnFYlL0A==",
+      "license": "ISC",
       "dependencies": {
         "debug": "^4.4.0",
         "eventemitter3": "^5.0.1",
@@ -5563,9 +5564,9 @@
       }
     },
     "mongochangestream": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.58.0.tgz",
-      "integrity": "sha512-UUs3JsyKORSJjqwg6ADV8GBYSptIHPO1I+E0RhFjjKk3B/14lgLb5OcKZrYo3DYg+ObysVZw2bkPPGzkdsuNcw==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.59.0.tgz",
+      "integrity": "sha512-MJBvX5YUXvv3/Hrl+fYlQ3AXFJaKJnUIyP3w3vkPyNAbvFSEZdmalaGKDlR2KHmM0osh5vTKUu/sq+QnFYlL0A==",
       "requires": {
         "debug": "^4.4.0",
         "eventemitter3": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/lodash": "^4.17.14",
         "@types/node": "^22.10.9",
         "@typescript-eslint/eslint-plugin": "^8.21.0",
-        "mongochangestream-testing": "^0.4.0",
+        "mongochangestream-testing": "^0.5.0",
         "prettier": "^3.4.2",
         "typescript": "^5.7.3",
         "vitest": "^3.0.4"
@@ -2710,13 +2710,15 @@
       }
     },
     "node_modules/mongochangestream-testing": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.4.0.tgz",
-      "integrity": "sha512-qVcdCoeSyu7eiQzhwmrQz32WZ4Cy9oTV2LXxD6fOWuqPcO7aV+/tnY7C6ZH4rInp1ueMsgWQOxf3jdLkbFyscw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.5.0.tgz",
+      "integrity": "sha512-n2hNIs4NG9rmne7v30cPzVIhb7P2xI0o/6fVc7qlWJtBb7j94CQZJylx+w5FzJs1BeHtONsypnDatSGuzwSKYg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "mongodb": "^6.12.0"
+        "mongodb": "^6.12.0",
+        "prom-utils": "^0.14.0"
       }
     },
     "node_modules/mongodb": {
@@ -5579,13 +5581,14 @@
       }
     },
     "mongochangestream-testing": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.4.0.tgz",
-      "integrity": "sha512-qVcdCoeSyu7eiQzhwmrQz32WZ4Cy9oTV2LXxD6fOWuqPcO7aV+/tnY7C6ZH4rInp1ueMsgWQOxf3jdLkbFyscw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.5.0.tgz",
+      "integrity": "sha512-n2hNIs4NG9rmne7v30cPzVIhb7P2xI0o/6fVc7qlWJtBb7j94CQZJylx+w5FzJs1BeHtONsypnDatSGuzwSKYg==",
       "dev": true,
       "requires": {
         "@faker-js/faker": "^9.3.0",
-        "mongodb": "^6.12.0"
+        "mongodb": "^6.12.0",
+        "prom-utils": "^0.14.0"
       }
     },
     "mongodb": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/lodash": "^4.17.14",
     "@types/node": "^22.10.9",
     "@typescript-eslint/eslint-plugin": "^8.21.0",
-    "mongochangestream-testing": "^0.4.0",
+    "mongochangestream-testing": "^0.5.0",
     "prettier": "^3.4.2",
     "typescript": "^5.7.3",
     "vitest": "^3.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo2mongo",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Sync one MongoDB collection to another MongoDB collection",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -44,7 +44,7 @@
     "debug": "^4.4.0",
     "eventemitter3": "^5.0.1",
     "lodash": "^4.17.21",
-    "mongochangestream": "^0.58.0",
+    "mongochangestream": "^0.59.0",
     "obj-walker": "^2.4.0",
     "p-retry": "^6.2.1",
     "prom-utils": "^0.14.0"

--- a/src/syncData.test.ts
+++ b/src/syncData.test.ts
@@ -2,6 +2,7 @@ import debug from 'debug'
 import Redis from 'ioredis'
 import _ from 'lodash/fp.js'
 import {
+  assertEventually,
   initCollection,
   initState as initRedisAndMongoState,
   numDocs,
@@ -9,44 +10,9 @@ import {
 import { MongoClient } from 'mongodb'
 import ms from 'ms'
 import { setTimeout } from 'node:timers/promises'
-import { TimeoutError, WaitOptions, waitUntil } from 'prom-utils'
-import { assert, describe, test } from 'vitest'
+import { describe, test } from 'vitest'
 
 import { initSync, SyncOptions } from './index.js'
-
-// FIXME: Pull in `assertEventually` from mongochangestream-testing instead.
-
-/**
- * Asserts that the provided predicate eventually returns true.
- *
- * @param pred - The predicate to check: an async function returning a boolean.
- * @param failureMessage - The message to display if the predicate does not
- * return true before the timeout.
- * @param [waitOptions] - Options to override the default options passed into
- * `waitUntil`.
- *
- * @throws AssertionError if the predicate does not return true before the
- * timeout.
- */
-export const assertEventually = async (
-  pred: () => Promise<boolean>,
-  failureMessage = 'Failed to satisfy predicate',
-  waitOptions: WaitOptions = {}
-) => {
-  try {
-    await waitUntil(pred, {
-      timeout: ms('60s'),
-      checkFrequency: ms('50ms'),
-      ...waitOptions,
-    })
-  } catch (e) {
-    if (e instanceof TimeoutError) {
-      assert.fail(failureMessage)
-    } else {
-      throw e
-    }
-  }
-}
 
 // Output via console.info (stdout) instead of stderr.
 // Without this debug statements are swallowed by vitest.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig(({ mode }) => ({
   test: {
     env: loadEnv(mode, process.cwd(), ''),
-    testTimeout: 30000,
+    testTimeout: 60000,
   },
 }))


### PR DESCRIPTION
This bumps the mongochangestream dependency to pick up the refresh token related improvements (https://github.com/smartprocure/mongochangestream/pull/37).

Tests are all passing with `assertEventually` in place. I currently have it inlined. Once https://github.com/smartprocure/mongochangestream-testing/pull/2 is merged and published, I will update this PR to use `assertEventually` from that library instead, and take the PR out of Draft.