### PR TITLE
Update `bulkWrite` response fields when summing the results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.35.0
+
+- Fixed [an issue](https://github.com/smartprocure/mongo2mongo/issues/3) where
+  the "process" event was being emitted with incorrect `success` and `failure`
+  values.
+
 # 0.34.0
 
 - Latest `mongochangestream` - Performance improvements related to updating the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo2mongo",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo2mongo",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo2mongo",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Sync one MongoDB collection to another MongoDB collection",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/syncData.ts
+++ b/src/syncData.ts
@@ -65,7 +65,12 @@ export const initSync = (
       ordered: true,
     })
     const numSuccess = _.flow(
-      _.pick(['nInserted', 'nModified', 'nRemoved', 'nUpserted']),
+      _.pick([
+        'insertedCount',
+        'modifiedCount',
+        'deletedCount',
+        'upsertedCount',
+      ]),
       Object.values,
       _.sum
     )(result)


### PR DESCRIPTION
Fixes https://github.com/smartprocure/mongo2mongo/issues/3.

As a sanity check, I went into `node_modules` and looked at the `BulkWriteResult` type, confirmed that these are the correct names of these fields.

The only thing this appears to affect is the `success` and `failed` numbers included in the "process" event object that we emit.